### PR TITLE
feat: support KUBECONFIG environment variable

### DIFF
--- a/internal/k8s/client.go
+++ b/internal/k8s/client.go
@@ -3,6 +3,7 @@ package k8s
 import (
 	"context"
 	"fmt"
+	"os"
 	"path/filepath"
 	"time"
 
@@ -22,7 +23,10 @@ type Client struct {
 }
 
 func NewClient() (*Client, error) {
-	kubeconfig := filepath.Join(homedir.HomeDir(), ".kube", "config")
+	kubeconfig := os.Getenv("KUBECONFIG")
+	if kubeconfig == "" {
+		kubeconfig = filepath.Join(homedir.HomeDir(), ".kube", "config")
+	}
 
 	config, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
 	if err != nil {


### PR DESCRIPTION
# Description
This PR adds support for the **KUBECONFIG** environment variable in the Kubernetes client initialization.

## Why this is needed
Standardizing with other Kubernetes tools (like `kubectl` or `k9s`), this change allows users to point to specific configuration files without relying solely on the default home directory path. This is especially useful for users managing multiple clusters or working in automated environments.

## Changes
- **Modified** `NewClient()` in `internal/k8s/client.go` to check for the `KUBECONFIG` environment variable.
- **Logic Update**: The application now prioritizes the path provided in the environment variable, falling back to the default `~/.kube/config` only if the variable is not set.
- **Imports**: Added the `"os"` package to handle environment variable lookups.